### PR TITLE
Twitter card image II

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -3,7 +3,7 @@ project:
   output-dir: docs
 
   resources:
-    - webLogo2.png
+    - "/webLogo2.png"
 
 website:
   site-url: https://matthewbjane.com
@@ -13,16 +13,16 @@ website:
   favicon: webLogoFavicon2.png
   
   open-graph:
-    image: webLogo2.png
+    image: "/webLogo2.png"
     locale: en_US
     
   twitter-card: 
     creator: "@MatthewBJane"
-    image: webLogo2.png
+    image: "/webLogo2.png"
   navbar:
     right: 
       - icon: github
-        href: https://www.github.io/MatthewBJane
+        href: https://www.github.com/MatthewBJane
       - icon: twitter
         href: https://www.twitter.com/MatthewBJane
       - icon: rss

--- a/index.qmd
+++ b/index.qmd
@@ -12,7 +12,7 @@ sansfont: Asap
 <div class="btn-group" role="group" aria-label="Social Links">
 [{{< fa envelope >}}<br>Email](mailto:matthew.jane@uconn.edu){.btn .btn-secondary .btn role="button" data-toggle="data" title="email"}
 [{{< fa brands twitter >}}<br>Twitter](https://www.twitter.com/MatthewBJane){.btn .btn-secondary .btn role="button" data-toggle="data" title="twitter"}
-[{{< fa brands github >}}<br>Github](https://www.github.io/MatthewBJane){.btn .btn-secondary .btn role="button" data-toggle="data" title="github"}
+[{{< fa brands github >}}<br>Github](https://www.github.com/MatthewBJane){.btn .btn-secondary .btn role="button" data-toggle="data" title="github"}
 [{{< fa graduation-cap >}}<br>Scholar](https://scholar.google.com/citations?user=a4C6CX0AAAAJ&hl=en){.btn .btn-secondary .btn role="button" data-toggle="data" title="scholar"}</div><br>
 
 Hello there! I'm **Matthew B. Jané** - I'm a PhD student in Quantitative Psychology at the University of Connecticut. My research involves developing statistical methods and software to aide in meta-analysis and evidence synthesis. Specifically, my current research projects focus on correcting bias in effect size estimates caused by statistical artifacts. My advisor is Dr. Blair T. Johnson and I am a member of the Systematic Health Action Research Program (SHARP). I am also on the editorial board for *Psychological Bulletin* as a methodological reviewer.


### PR DESCRIPTION
Next try to fix the twitter card image.

I noticed that the path name is absolute from the root dir `/` and enclosed in quotes `"/link/to/img.png"` in the Quarto documentation: https://quarto.org/docs/websites/website-tools.html#twitter-cards 


Minor: fixed the GitHub link in `_quarto.yaml` and `index.qmd`