### PR TITLE
add blog thumbnail image to resources

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -4,6 +4,7 @@ project:
 
   resources:
     - "/webLogo2.png"
+    - "/blog-image.png"
 
 website:
   site-url: https://matthewbjane.com


### PR DESCRIPTION
The link to the twitter card image is set correctly (see <https://www.opengraph.xyz/url/https%3A%2F%2Fmatthewbjane.com%2Fblog.html>) but the image is not hosted under `docs/`. This PR should let Quarto add the image so that the preview works.